### PR TITLE
eventPosition計算方式修正，js寫法修改

### DIFF
--- a/src/components/read/EbookReader.vue
+++ b/src/components/read/EbookReader.vue
@@ -206,17 +206,13 @@
         this.refreshLocation([true, true])
       },
       initEvent() {
-        let vueInstance = this
         const mousewheel = /Firefox/i.test(navigator.userAgent) ? 'DOMMouseScroll' : 'mousewheel'
-        this.rendition.hooks.content.register(function (contents) {
+        this.rendition.hooks.content.register((contents) => {
           const baseName = contents.cfiBase.match(/\[(.*?)\]/)[1]
-          vueInstance.navigation.forEach((navItem) => {
+          this.navigation.forEach((navItem) => {
             if (navItem.href.indexOf(baseName) !== -1) {
               const href = navItem.href.match(/\/(.*?)$/)[1]
-              let id = undefined
-              if (href.indexOf('#') !== -1) {
-                id = href.split('#')[1]
-              }
+              const id = href.replace(/^([^#]*)#?(.*)$/, '$2')
               if (id) {
                 //得到每个目录的cfi地址
                 const node = contents.document.getElementById(id)
@@ -226,20 +222,19 @@
             }
           })
           handleNote(contents.document) // 处理注释
-          contents.window.addEventListener(mousewheel, vueInstance.handleMouseWheel, true)
-          contents.window.addEventListener('keydown', vueInstance.handleKeyDown)
-          if (vueInstance.isMobile) {
-            contents.document.addEventListener('touchmove', (e) => {
-              if (!vueInstance.enableTouch) {
-                vueInstance.enableTouch = true
-              }
+          contents.window.addEventListener(mousewheel, this.handleMouseWheel, true)
+          contents.window.addEventListener('keydown', this.handleKeyDown)
+
+          if (this.isMobile) {
+            contents.document.addEventListener('touchmove', () => {
+              this.enableTouch = true
             })
             contents.document.addEventListener(
               'touchstart',
               (e) => {
                 // console.log('touch', e)
-                vueInstance.timeStart = e.timeStamp
-                vueInstance.touchDetail = e
+                this.timeStart = e.timeStamp
+                this.touchDetail = e
               },
               true
             )
@@ -248,11 +243,11 @@
               'touchend',
               (e) => {
                 // console.log('touchend', e)
-                if (!vueInstance.enableTouch) {
+                if (!this.enableTouch) {
                   e.stopPropagation()
-                  vueInstance.handleMouseDown(e)
+                  this.handleMouseDown(e)
                 } else {
-                  vueInstance.enableTouch = false
+                  this.enableTouch = false
                 }
               },
               true
@@ -260,7 +255,7 @@
           }
         })
         // 单击事件
-        if (!vueInstance.isMobile) {
+        if (!this.isMobile) {
           this.rendition.on('mousedown', (e) => {
             this.timeStart = e.timeStamp
           })

--- a/src/components/read/EbookReader.vue
+++ b/src/components/read/EbookReader.vue
@@ -173,16 +173,15 @@
       async initEpub(book, cfi) {
         this.updateBook(book)
         // 指定渲染的位置和方式
-        let option = {
-          width: this.width,
-          height: window.innerHeight,
-          manager: this.epubJsManager,
-          snap: this.isMobile
-        }
-        if (this.epubJsFlow !== 'none') option.flow = this.epubJsFlow
         this.rendition = await this.getRendition({
           element: 'read',
-          option: option
+          option: {
+            width: this.width,
+            height: window.innerHeight,
+            manager: this.epubJsManager,
+            snap: this.isMobile,
+            ...(this.epubJsFlow !== 'none' ? { flow: this.epubJsFlow } : {})
+          }
         })
 
         this.rendition.display(cfi)

--- a/src/components/read/EbookReader.vue
+++ b/src/components/read/EbookReader.vue
@@ -58,6 +58,9 @@
       },
       isMobile() {
         return IsMobile()
+      },
+      Epub() {
+        return this.epubJsVersion === 'last.chinese' ? EpubLast : Epub85
       }
     },
     methods: {
@@ -322,12 +325,6 @@
         const screenWidth = Math.round(window.innerWidth)
         const remainder = screenWidth % 8
         this.width = screenWidth - remainder
-      },
-      getEpubJsType() {
-        // 获取需要使用的epub.js版本
-        let type = Epub85
-        if (this.epubJsVersion === 'last.chinese') type = EpubLast
-        return type
       }
     },
     destroyed() {
@@ -337,33 +334,30 @@
       this.getWidth()
       if (window.device) {
         // 连接App调试
-        let vueInstance = this
+        const { updateBookHash, Epub, initEpub } = this
         window.loadBook = function (path, url) {
           let hash = md5(path)
-          vueInstance.updateBookHash(hash)
-          let type = vueInstance.getEpubJsType()
+          updateBookHash(hash)
           if (!url.startsWith('/')) {
             console.log('base64')
             let data = toByteArray(url)
             console.log(data.length)
-            let book = new type()
+            let book = new Epub()
             book.open(data.buffer).then(() => {
-              vueInstance.initEpub(book, GetReadProgress(hash))
+              initEpub(book, GetReadProgress(hash))
             })
+          } else if (window.location.origin === 'file://') {
+            initEpub(new Epub(url), GetReadProgress(hash))
           } else {
-            if (window.location.origin === 'file://') {
-              vueInstance.initEpub(new type(url), GetReadProgress(hash))
-            } else {
-              window.device.readFileBase64(url)
-            }
+            window.device.readFileBase64(url)
           }
         }
         window.device.readBook()
       } else {
+        const { updateBookHash, initEpub, Epub } = this
         const fileName = 'Test2.epub'
-        this.updateBookHash(fileName)
-        let type = this.getEpubJsType()
-        this.initEpub(new type(fileName), GetReadProgress(fileName))
+        updateBookHash(fileName)
+        initEpub(new Epub(fileName), GetReadProgress(fileName))
       }
     }
   }

--- a/src/components/read/EbookReader.vue
+++ b/src/components/read/EbookReader.vue
@@ -188,19 +188,22 @@
 
         this.initEvent()
         this.parseBook()
-        book.ready
-          .then(() => {
-            window.device?.setResultOK()
-            // 修改网页title
-            document.title = book.package.metadata.title
-            // return this.book.locations.generate(750 * (window.innerWidth / 375) * bookState.defaultFontSize / 16)
-            return book.locations.generate()
-          })
-          .then(() => {
-            // 书籍加载完毕
-            this.updateBookAvailable(true)
-            this.refreshLocation([true, true])
-          })
+
+        const [, bookError] = await book.ready.then((res) => [res, null]).catch((err) => [null, err])
+        if (bookError) return
+
+        window.device?.setResultOK()
+        // 修改网页title
+        document.title = book.package.metadata.title
+        // return this.book.locations.generate(750 * (window.innerWidth / 375) * bookState.defaultFontSize / 16)
+        const [, locationError] = await book.locations
+          .generate()
+          .then((res) => [res, null])
+          .catch((err) => [null, err])
+        if (locationError) return
+        // 书籍加载完毕
+        this.updateBookAvailable(true)
+        this.refreshLocation([true, true])
       },
       initEvent() {
         let vueInstance = this


### PR DESCRIPTION
## Bug
無法翻頁和叫出menu

## Env
### test case 1
chrome desktop(1920x1080)
### test case 2
chrome mobile

## Step
### test case 1
1. 開啟Test2.epub
2. 點擊螢幕右側翻頁
3. 出現menu(不該出現)
### test case 2
1. 開啟Test3.epub
2. 選目錄到第一章
3. 翻頁
4. 點擊螢幕中間
5. 無反應(應該出現menu)

## Description
test case 1主因是由於電腦版畫面會render出兩頁所以需要另外處理pageX相對螢幕的實際位置
test case 2在chrome會render出直式，翻頁後pageY數值會變大超出判斷範圍

最後改法為使用`.epub-container`的scrollPosition和該頁面`.epub-view`的offsetPosition計算出eventPosition

其他修改是在閱讀code時一併改的

